### PR TITLE
Check for duplicate symbols

### DIFF
--- a/tools/process_symbol_map.py
+++ b/tools/process_symbol_map.py
@@ -248,7 +248,7 @@ class Map:
     def __parse_variables(self, key, value):
         for var_name in value.keys():
             if var_name in self.var_list:
-                self.__unsupported(f"Found duplicate variable: '{var_name}'")
+                print(f"Found duplicate variable: '{var_name}'")
                 continue
 
             self.var_list.append(var_name)

--- a/tools/process_symbol_map.py
+++ b/tools/process_symbol_map.py
@@ -210,7 +210,6 @@ class Map:
         for vtable in self.vtables.keys():
             self.__process_vtable(vtable)
 
-
     def __add_func(self, version: str, name: str, mangled_name: str, addr: str):
         full_addr = Map.__addr_helper(addr, mangled_name)
 
@@ -229,7 +228,7 @@ class Map:
         for obj in value:
             mangled_name = obj["name"]
             if any(item[1] == mangled_name for item in self.symbol_list):
-                print(f"Found duplicate symbol: {mangled_name}")
+                print(f"Found duplicate symbol: '{mangled_name}'")
                 continue
 
             name = Windows.mangle_to_var(mangled_name)
@@ -248,6 +247,10 @@ class Map:
 
     def __parse_variables(self, key, value):
         for var_name in value.keys():
+            if var_name in self.var_list:
+                self.__unsupported(f"Found duplicate variable: '{var_name}'")
+                continue
+
             self.var_list.append(var_name)
             addr = value[var_name]
             if type(addr) is str:
@@ -382,8 +385,6 @@ class Map:
         out.cxx("}")
         out.cxx("")
 
-
-
 # Supported Platforms
 class Windows:
     def mangle_to_var(name):
@@ -446,7 +447,6 @@ class Windows:
             case _:
                 print(f"Unsupported arch: {arch}")
 
-
 def generate(args: Args, out: Output, map: Map):
     file_comment = "This file was automatically generated using tools/" + os.path.basename(__file__)
     gen_time = datetime.datetime.utcnow().strftime("%a %b %d %Y %H:%M:%S UTC")
@@ -502,8 +502,6 @@ def should_rebuild_symbols(args: Args) -> bool:
         return True
     
     return False
-
-
 
 args = Args()
 if should_rebuild_symbols(args):

--- a/tools/process_symbol_map.py
+++ b/tools/process_symbol_map.py
@@ -228,6 +228,10 @@ class Map:
     def __parse_funcs(self, value):
         for obj in value:
             mangled_name = obj["name"]
+            if any(item[1] == mangled_name for item in self.symbol_list):
+                print(f"Found duplicate symbol: {mangled_name}")
+                continue
+
             name = Windows.mangle_to_var(mangled_name)
             addr = obj["address"]
 


### PR DESCRIPTION
Changes: I have added a section of code to skip any duplicate symbol names
Motivation: Duplicate symbol's were causing my build to fail without any actual indication on why. Should be a good quality of life change to help debug stupid mistakes

Before:
```
Severity	Code	Description	Project	File	Line	Suppression State
Error	MSB3721	The command ""C:/Program Files/NASM/nasm.exe" -o "Example.dir\Release\initasm.obj" -fwin64 -I"C:\Users\blake\AppData\Roaming\Zenova\dev\inc\\" -I"C:\Users\blake\Desktop\Template-master\inc\\" -I"C:\Users\blake\Desktop\Template-master\src\\" -D"WIN32" -D"_WINDOWS" -D"NDEBUG" -D"CMAKE_INTDIR="Release"" -D"Example_EXPORTS"  "C:\Users\blake\Desktop\Template-master\src\generated\initasm.asm"" exited with code 1.	Example	C:\Program Files\CMake\share\cmake-3.26\Templates\MSBuild\nasm.targets	33	
```

After:
```
1>Found duplicate symbol: ?registerDimensionTypes@VanillaDimensionFactory@@YAXAEAV?$Factory@VDimension@@AEAVLevel@@AEAVScheduler@@@@@Z
```