### PR TITLE
Rewrite vtable parsing

### DIFF
--- a/tools/process_symbol_map.py
+++ b/tools/process_symbol_map.py
@@ -185,7 +185,6 @@ class Map:
             
         return [ func ]
 
-    # todo: add support for multi inheritance vtables, should be easy with new implementation
     def __process_vtable(self, name: str, vtable: dict):
         noclass_funcs = vtable.setdefault("noclass_funcs", [])
 
@@ -377,15 +376,15 @@ class Map:
         if len(self.symbol_list) > 0 or len(self.parsed_vtables) > 0:
             out.header("")
             out.header("extern \"C\" {")
-            for name, _ in self.symbol_list:
-                if name:
-                    out.header("\textern void* " + name + "_ptr;")
             for name, vtable in self.parsed_vtables.items():
                 out.header("\textern void* " + name + "_vtable;")
 
                 if len(vtable["address"]) > 1:
                     for source in vtable["source"][1:]:
                         out.header(f"\textern void* {name}_{source}_vtable;")
+            for name, _ in self.symbol_list:
+                if name:
+                    out.header("\textern void* " + name + "_ptr;")
             for a in self.vdtor_list:
                 if a["name"]:
                     out.header("\textern void* " + a["name"] + "_ptr;")
@@ -543,7 +542,7 @@ class Windows:
             for symbol, offset, vtable_offset in vtable["functions"]:
                 if symbol != "":
                     vtable_name = name
-                    if vtable_offset > 0:
+                    if len(vtable["address"]) > 1 and vtable_offset > 0:
                         vtable_name += "_" + vtable["source"][vtable_offset]
 
                     out.asm("global " + symbol)

--- a/tools/process_symbol_map.py
+++ b/tools/process_symbol_map.py
@@ -87,7 +87,7 @@ class Map:
     # 0 = var_name, 1 = mangled_name (sorry)
     symbol_list = []
     symbol_dict = {}
-    # cached isn't the best name, holds onto vtables that can't be parsed yet
+    # holds onto vtables that can't be parsed yet
     cached_vtables = {}
     direct_vtables = {}
     parsed_vtables = {}
@@ -111,6 +111,14 @@ class Map:
         except json.decoder.JSONDecodeError:
             print(f"Cannot parse '{file.name}', file does not contain valid JSON")
             return
+        
+        vtable_count = len(self.cached_vtables)
+        if vtable_count > 0:
+            print(f"{vtable_count} unparsed vtable{'s'[:vtable_count^1]}:")
+
+            for name, vtable in self.cached_vtables.items():
+                parent = list(filter(lambda i: i not in self.parsed_vtables, vtable["parent"]))
+                print(f" - {name} is missing parent{'s'[:len(parent)^1]}: {parent}")
         
         num_issues = len(self.current_file_issues)
         # Don't print any info for succesfully parsed files


### PR DESCRIPTION
What's added so far: multi-inheritance support, vtable caching

Multi-Inheritance ex for 1.14.60:
```json
"name": "RandomizableBlockActorFillingContainer",
"parent": [ "RandomizableBlockActorContainerBase", "FillingContainer" ],
"address": "0x2B89208",
"functions": [...]

"name": "ChestBlockActor",
"parent": "RandomizableBlockActorFillingContainer",
"address": [ "0x2B86530", "0x2B863F0" ],
"functions": [...]
```
```cpp
void* ChestBlockActor_vtable = SlideAddress(0x2B86530);
void* ChestBlockActor_FillingContainer_vtable = SlideAddress(0x305DDA0);
```

Vtable Caching:
Enables lenient vtable ordering and the ability to use a parent vtable in another symbol map (this should close #16), I also forgot to add this in the initial commit but it'll warn you if any are left in the cache when the script finishes parsing all the maps