### PR TITLE
Basic dependency order system!

### DIFF
--- a/src/Zenova/Helper.cpp
+++ b/src/Zenova/Helper.cpp
@@ -26,7 +26,7 @@ namespace Zenova {
 
 		bool run = (PlatformImpl::Init(platformArgs) && !manager.dataFolder.empty());
 		if (run) {
-			logger.info("Zenova Started (Dev)");
+			logger.info("Zenova Started");
 			logger.info("ZenovaData Location: {}", manager.dataFolder);
 
 			logger.info("Minecraft's Version: {}", Minecraft::version().toString());

--- a/src/Zenova/Helper.cpp
+++ b/src/Zenova/Helper.cpp
@@ -26,7 +26,7 @@ namespace Zenova {
 
 		bool run = (PlatformImpl::Init(platformArgs) && !manager.dataFolder.empty());
 		if (run) {
-			logger.info("Zenova Started");
+			logger.info("Zenova Started (Dev)");
 			logger.info("ZenovaData Location: {}", manager.dataFolder);
 
 			logger.info("Minecraft's Version: {}", Minecraft::version().toString());

--- a/src/Zenova/Profile/Manager.h
+++ b/src/Zenova/Profile/Manager.h
@@ -28,6 +28,7 @@ namespace Zenova {
         void update();
         void load(const ProfileInfo& profile);
         void swap(const ProfileInfo& profile);
+        void loadMod(const std::string& modName);
         std::string getVersion();
         size_t getModCount();
 

--- a/src/Zenova/Profile/ModInfo.cpp
+++ b/src/Zenova/Profile/ModInfo.cpp
@@ -8,27 +8,52 @@
 #include "Zenova/JsonHelper.h"
 
 namespace Zenova {
-    ModInfo::ModInfo(const std::string& modFolder) {
-        json::Document modDocument = JsonHelper::OpenFile(modFolder + "modinfo.json");
+    ModInfo::ModInfo(const std::string& modFolder) :
+        mModFolder(modFolder)
+    {
+        json::Document modDocument = JsonHelper::OpenFile(mModFolder + "modinfo.json");
         if(!modDocument.IsNull()) {
             mNameId = JsonHelper::FindString(modDocument, "nameId");
             mName = JsonHelper::FindString(modDocument, "name");
             mDescription = JsonHelper::FindString(modDocument, "description");
             mVersion = JsonHelper::FindString(modDocument, "version");
-
-            mHandle = Platform::LoadModule(modFolder + mNameId);
+            auto& dependenciesObject = JsonHelper::FindMember(modDocument, "dependencies", false);
+            if (!dependenciesObject.IsNull() && dependenciesObject.IsArray())
+            {
+                for (auto& object : dependenciesObject.GetArray())
+                {
+                    mDependencies.push_back(object.GetString());
+                }
+            }
         }
     }
 
     ModInfo::ModInfo(ModInfo&& mod) noexcept :
         mHandle(std::exchange(mod.mHandle, nullptr)),
+        mModFolder(std::move(mod.mModFolder)),
         mNameId(std::move(mod.mNameId)),
         mName(std::move(mod.mName)),
         mDescription(std::move(mod.mDescription)),
-        mVersion(std::move(mod.mVersion))
+        mVersion(std::move(mod.mVersion)),
+        mDependencies(std::move(mod.mDependencies))
     {}
 
     ModInfo::~ModInfo() {
         if(mHandle) Platform::CloseModule(mHandle);
+    }
+
+    void* ModInfo::loadModule()
+    {
+        loadDependencies();
+        mHandle = Platform::LoadModule(mModFolder + mNameId);
+        return mHandle;
+    }
+
+    void ModInfo::loadDependencies() const
+    {
+        for (auto& dependencyName : mDependencies)
+        {
+            manager.loadMod(dependencyName);
+        }
     }
 }

--- a/src/Zenova/Profile/ModInfo.h
+++ b/src/Zenova/Profile/ModInfo.h
@@ -1,18 +1,28 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
 #include <vector>
+
+#include "Zenova/Minecraft/Version.h"
 
 namespace Zenova {
 	class Mod;
 
     struct ModInfo {
 		void* mHandle = nullptr;
-		std::string mNameId, mName = "", mDescription = "";
+    	std::string mModFolder = "";
+		std::string mNameId = "";
+    	std::string mName = "";
+    	std::string mDescription = "";
 		std::string mVersion = "";
+    	std::vector<std::string> mDependencies = {};
 
 		ModInfo(const std::string& modFolder);
 		ModInfo(ModInfo&&) noexcept;
 		~ModInfo();
+
+    	void* loadModule();
+    	void loadDependencies() const;
 	};
 }


### PR DESCRIPTION
That change will not do anything a lot special, its just a change to be able to put the dependency NameID into the modinfo.json, and then the dependency will load first than the mod if the order of Mod/Dependency is wrong on the profile config.

![image](https://github.com/MinecraftZenova/ZenovaAPI/assets/75029692/89baa23b-151f-4f40-9aec-cfe027b5b952)
