### PR TITLE
Dependency work and manual module import table resolver

### DIFF
--- a/inc/Zenova/Mod.h
+++ b/inc/Zenova/Mod.h
@@ -1,14 +1,20 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include "Common.h"
+#include "Zenova/Profile/ModInfo.h"
 
 #define MOD_FUNCTION extern "C" __declspec(dllexport)
 
 struct EXPORT ModContext {
 	std::string folder;
 };
+
+namespace Zenova {
+	EXPORT std::vector<Zenova::ModInfo>& GetMods();
+}
 
 // Define any/all of these functions
 

--- a/inc/Zenova/Platform.h
+++ b/inc/Zenova/Platform.h
@@ -22,6 +22,8 @@ namespace Zenova {
 		Execute = 8
 	};
 
+	struct ModInfo;
+
 	inline ProtectionFlags operator|(ProtectionFlags a, ProtectionFlags b) {
 		return static_cast<ProtectionFlags>(enum_cast(a) | enum_cast(b));
 	}
@@ -45,6 +47,8 @@ namespace Zenova {
 		static uintptr_t GetModuleBaseAddress(const std::wstring& modName);
 		static u32 GetModuleSize(const char*);
 		static void* LoadModule(const std::string& module);
+		static void* LoadModModuleAndResolveImports(const ModInfo& modInfo, const std::string& module);
+		static void ResolveModModuleImports(const ModInfo& modInfo, void* hModule, const std::string& moduleName);
 		static bool CloseModule(void*);
 		static void* GetModuleFunction(void* module, const std::string& function);
 

--- a/inc/Zenova/Profile/ModInfo.h
+++ b/inc/Zenova/Profile/ModInfo.h
@@ -16,13 +16,12 @@ namespace Zenova {
     	std::string mName = "";
     	std::string mDescription = "";
 		std::string mVersion = "";
-    	std::vector<std::string> mDependencies = {};
-
+#ifdef ZENOVA_API
 		ModInfo(const std::string& modFolder);
 		ModInfo(ModInfo&&) noexcept;
 		~ModInfo();
 
     	void* loadModule();
-    	void loadDependencies() const;
+#endif
 	};
 }

--- a/src/Zenova/Helper.cpp
+++ b/src/Zenova/Helper.cpp
@@ -26,7 +26,7 @@ namespace Zenova {
 
 		bool run = (PlatformImpl::Init(platformArgs) && !manager.dataFolder.empty());
 		if (run) {
-			logger.info("Zenova Started (Dev)");
+			logger.info("Zenova Started");
 			logger.info("ZenovaData Location: {}", manager.dataFolder);
 
 			logger.info("Minecraft's Version: {}", Minecraft::version().toString());

--- a/src/Zenova/Helper.cpp
+++ b/src/Zenova/Helper.cpp
@@ -26,7 +26,7 @@ namespace Zenova {
 
 		bool run = (PlatformImpl::Init(platformArgs) && !manager.dataFolder.empty());
 		if (run) {
-			logger.info("Zenova Started");
+			logger.info("Zenova Started (Dev)");
 			logger.info("ZenovaData Location: {}", manager.dataFolder);
 
 			logger.info("Minecraft's Version: {}", Minecraft::version().toString());

--- a/src/Zenova/Hooks/InputHooks.h
+++ b/src/Zenova/Hooks/InputHooks.h
@@ -92,7 +92,7 @@ namespace Zenova {
 
 	static void (*__handleDuplicates)(ControlsSettingsScreenController*, RemappingLayout&);
 	void _handleDuplicates(ControlsSettingsScreenController* self, RemappingLayout& a2) {}
-
+	
 	inline void createInputHooks() {
 		Zenova_Hook(MinecraftInputHandler::_registerInputHandlers, &_registerInputHandlers, &__registerInputHandlers);
 
@@ -102,7 +102,7 @@ namespace Zenova {
 		Zenova_Hook(VanillaClientInputMappingFactory::_populateGamepadDefaults, &_populateGamepadDefaults, &__populateGamepadDefaults);
 		Zenova_Hook(VanillaClientInputMappingFactory::_addFullKeyboardGamePlayControls, &_addFullKeyboardGamePlayControls, &__addFullKeyboardGamePlayControls);
 		Zenova_Hook(VanillaClientInputMappingFactory::_addInvariantGamePlayGameControllerControls, &_addInvariantGamePlayGameControllerControls, &__addInvariantGamePlayGameControllerControls);
-
 		Zenova_Hook(ControlsSettingsScreenController::_handleDuplicates, &_handleDuplicates, &__handleDuplicates);
+		
 	}
 }

--- a/src/Zenova/Mod.cpp
+++ b/src/Zenova/Mod.cpp
@@ -1,0 +1,7 @@
+#include "Zenova/Mod.h"
+#include "Zenova/Globals.h"
+
+EXPORT std::vector<Zenova::ModInfo>& Zenova::GetMods()
+{
+	return manager.getMods();
+}

--- a/src/Zenova/Profile/Manager.cpp
+++ b/src/Zenova/Profile/Manager.cpp
@@ -102,30 +102,38 @@ namespace Zenova {
         load(profile);
     }
 
-    void Manager::loadMod(const std::string& modName)
+    void* Manager::loadMod(const std::string& modName)
     {
         if (std::find_if(mods.begin(), mods.end(),
         [&modName](const ModInfo& mod) { return mod.mNameId == modName; }) != mods.end())
-            return;
+            return nullptr;
             
         logger.info("Loading {}", modName);
 
         // todo: verify path
         std::string folder = manager.dataFolder + "\\mods\\" + modName + "\\";
         ModInfo mod(folder);
+        void* modHandle = mod.loadModule();
 
-        if (mod.loadModule()) {
+        if (modHandle) {
             ModContext ctx = { folder };
             CALL_MOD_FUNC(mod, ModLoad, ctx)
 
             PackManager::addMod(folder);
 
             mods.push_back(std::move(mod));
+            return modHandle;
         }
         else {
             logger.warn("Failed to load {}", mod.mName);
             Platform::ErrorPrinter();
+            return nullptr;
         }
+    }
+
+    std::vector<ModInfo>& Manager::getMods()
+    {
+        return mods;
     }
 
     std::string Manager::getVersion() {

--- a/src/Zenova/Profile/Manager.h
+++ b/src/Zenova/Profile/Manager.h
@@ -5,7 +5,7 @@
 #include <vector>
 
 #include "ProfileInfo.h"
-#include "ModInfo.h"
+#include "Zenova/Profile/ModInfo.h"
 
 namespace Zenova {
     class Manager {
@@ -28,7 +28,8 @@ namespace Zenova {
         void update();
         void load(const ProfileInfo& profile);
         void swap(const ProfileInfo& profile);
-        void loadMod(const std::string& modName);
+        void* loadMod(const std::string& modName);
+        std::vector<ModInfo>& getMods();
         std::string getVersion();
         size_t getModCount();
 

--- a/src/Zenova/Profile/Manager.h
+++ b/src/Zenova/Profile/Manager.h
@@ -28,6 +28,7 @@ namespace Zenova {
         void update();
         void load(const ProfileInfo& profile);
         void swap(const ProfileInfo& profile);
+        void loadMod(const std::string& modName);
         std::string getVersion();
         size_t getModCount();
 

--- a/src/Zenova/Profile/ModInfo.cpp
+++ b/src/Zenova/Profile/ModInfo.cpp
@@ -8,27 +8,52 @@
 #include "Zenova/JsonHelper.h"
 
 namespace Zenova {
-    ModInfo::ModInfo(const std::string& modFolder) {
-        json::Document modDocument = JsonHelper::OpenFile(modFolder + "modinfo.json");
+    ModInfo::ModInfo(const std::string& modFolder) :
+        mModFolder(modFolder)
+    {
+        json::Document modDocument = JsonHelper::OpenFile(mModFolder + "modinfo.json");
         if(!modDocument.IsNull()) {
             mNameId = JsonHelper::FindString(modDocument, "nameId");
             mName = JsonHelper::FindString(modDocument, "name");
             mDescription = JsonHelper::FindString(modDocument, "description");
             mVersion = JsonHelper::FindString(modDocument, "version");
-
-            mHandle = Platform::LoadModule(modFolder + mNameId);
+            auto& dependenciesObject = JsonHelper::FindMember(modDocument, "dependencies", false);
+            if (!dependenciesObject.IsNull() && dependenciesObject.IsArray())
+            {
+                for (auto& object : dependenciesObject.GetArray())
+                {
+                    mDependencies.push_back(object.GetString());
+                }
+            }
         }
     }
 
     ModInfo::ModInfo(ModInfo&& mod) noexcept :
         mHandle(std::exchange(mod.mHandle, nullptr)),
+        mModFolder(std::move(mod.mModFolder)),
         mNameId(std::move(mod.mNameId)),
         mName(std::move(mod.mName)),
         mDescription(std::move(mod.mDescription)),
-        mVersion(std::move(mod.mVersion))
+        mVersion(std::move(mod.mVersion)),
+        mDependencies(std::move(mod.mDependencies))
     {}
 
     ModInfo::~ModInfo() {
         if(mHandle) Platform::CloseModule(mHandle);
+    }
+
+    void* ModInfo::loadModule()
+    {
+        loadDependencies();
+        mHandle = Platform::LoadModule(mModFolder + mNameId);
+        return mHandle;
+    }
+
+    void ModInfo::loadDependencies() const
+    {
+        for (auto& dependencyName : mDependencies)
+        {
+            manager.loadMod(dependencyName);
+        }
     }
 }

--- a/src/Zenova/Profile/ModInfo.cpp
+++ b/src/Zenova/Profile/ModInfo.cpp
@@ -1,4 +1,4 @@
-#include "ModInfo.h"
+#include "Zenova/Profile/ModInfo.h"
 
 #include <fstream>
 #include <utility>
@@ -17,14 +17,6 @@ namespace Zenova {
             mName = JsonHelper::FindString(modDocument, "name");
             mDescription = JsonHelper::FindString(modDocument, "description");
             mVersion = JsonHelper::FindString(modDocument, "version");
-            auto& dependenciesObject = JsonHelper::FindMember(modDocument, "dependencies", false);
-            if (!dependenciesObject.IsNull() && dependenciesObject.IsArray())
-            {
-                for (auto& object : dependenciesObject.GetArray())
-                {
-                    mDependencies.push_back(object.GetString());
-                }
-            }
         }
     }
 
@@ -34,8 +26,7 @@ namespace Zenova {
         mNameId(std::move(mod.mNameId)),
         mName(std::move(mod.mName)),
         mDescription(std::move(mod.mDescription)),
-        mVersion(std::move(mod.mVersion)),
-        mDependencies(std::move(mod.mDependencies))
+        mVersion(std::move(mod.mVersion))
     {}
 
     ModInfo::~ModInfo() {
@@ -44,16 +35,7 @@ namespace Zenova {
 
     void* ModInfo::loadModule()
     {
-        loadDependencies();
-        mHandle = Platform::LoadModule(mModFolder + mNameId);
+        mHandle = Platform::LoadModModuleAndResolveImports(*this, mModFolder + mNameId);
         return mHandle;
-    }
-
-    void ModInfo::loadDependencies() const
-    {
-        for (auto& dependencyName : mDependencies)
-        {
-            manager.loadMod(dependencyName);
-        }
     }
 }

--- a/src/Zenova/Profile/ModInfo.h
+++ b/src/Zenova/Profile/ModInfo.h
@@ -1,18 +1,28 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
 #include <vector>
+
+#include "Zenova/Minecraft/Version.h"
 
 namespace Zenova {
 	class Mod;
 
     struct ModInfo {
 		void* mHandle = nullptr;
-		std::string mNameId, mName = "", mDescription = "";
+    	std::string mModFolder = "";
+		std::string mNameId = "";
+    	std::string mName = "";
+    	std::string mDescription = "";
 		std::string mVersion = "";
+    	std::vector<std::string> mDependencies = {};
 
 		ModInfo(const std::string& modFolder);
 		ModInfo(ModInfo&&) noexcept;
 		~ModInfo();
+
+    	void* loadModule();
+    	void loadDependencies() const;
 	};
 }

--- a/src/Zenova/Utils/Memory.cpp
+++ b/src/Zenova/Utils/Memory.cpp
@@ -1,0 +1,14 @@
+#include "Memory.h"
+#include "Windows.h"
+
+namespace Zenova {
+	void Memory::WriteOnProtectedAddress(void* address, void* data, size_t size) {
+		if (!address || !data || !size)
+			return;
+
+		DWORD old = 0;
+		VirtualProtect(address, size, PAGE_EXECUTE_READWRITE, &old);
+		memcpy_s(address, size, data, size);
+		VirtualProtect(address, size, old, NULL);
+	}
+}

--- a/src/Zenova/Utils/Memory.h
+++ b/src/Zenova/Utils/Memory.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace Zenova {
+	class Memory {
+	public:
+		static void WriteOnProtectedAddress(void* address, void* data, size_t dataSize);
+	};
+}

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -1,14 +1,16 @@
 //
 // This is for the Windows version of Zenova
 //
-
 #include <Windows.h>
 
 #include "Zenova/Platform.h"
 #include "Zenova/Helper.h"
 #include "generated/initcpp.h"
+#include "Zenova/Log.h"
+#include "winnt.h"
 
 DWORD WINAPI call_run(LPVOID args) {
+
 	return Zenova::run();
 }
 
@@ -16,7 +18,6 @@ BOOL APIENTRY DllMain(HMODULE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
 	// avoid being attached to anything besides Minecraft Win10
 	if ((fdwReason == DLL_PROCESS_ATTACH) && Zenova::Platform::GetMinecraftBaseAddress()) {
 		InitBedrockPointers();
-
 		auto args = reinterpret_cast<LPVOID>(hinstDLL);
 		// block run till everything is initialized
 		if (Zenova::start(args)) {


### PR DESCRIPTION
No need to specify the dependency array anymore, the import resolver will automatically load the dependency mod if it isn't loaded and populate the (Import Address Table) with the right addresses from the GetProcAddress with the names from the (Import Lookup Table) of the mod dll.